### PR TITLE
pr.conf comment: weekly_rankings.py to rankings_cli.py

### DIFF
--- a/fbpowerrankings/pr.conf
+++ b/fbpowerrankings/pr.conf
@@ -26,5 +26,5 @@ lowerBetter=ERA,WHIP,L
 
 # URL where rankings are being hosted
 # For more flexbility, set this value directly in the code
-# Look for the comment RANKINGS URL HERE in weekly_rankings.py
+# Look for the comment RANKINGS URL HERE in rankings_cli.py
 rankingsUrl=http://www.example.com/power-rankings


### PR DESCRIPTION
There is a comment in pr.conf that instructs users to 

"# Look for the comment RANKINGS URL HERE in weekly_rankings.py"

There is no longer a file called weekly_rankings.py in the current package. 

"# Look for the comment RANKINGS URL HERE in weekly_rankings.py"
does, however, appear in rankings_cli.py. 